### PR TITLE
Fix an infinite loop.

### DIFF
--- a/metar/readerJpeg.nim
+++ b/metar/readerJpeg.nim
@@ -374,7 +374,7 @@ proc readSectionsRaw(file: File): seq[Section] =
     if length < 2:
       raise newException(NotSupportedError, "Jpeg: block is less than 2 bytes.")
 
-    finish = start + int64(length + 2)
+    finish = start + int64(length) + 2
     result.add((marker, start, finish))
     file.setFilePos(finish)
 


### PR DESCRIPTION
I got a jpeg where one section's length was exactly 65534, which overflowed uint16 after +2, resulting in an infinite loop. Fixing the calculation resolved the issue with the jpeg.